### PR TITLE
Added permanent palette-swap controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,17 @@
 # kanadex
+Custom content gallery for [World of Horror](https://store.steampowered.com/app/913740/WORLD_OF_HORROR/).
+This is unofficial and not affiliated with the developer panstasz or the publisher ysbrd games.  
+Please support the official release.
 
-## client/BitCanvas
-Component for pallete swapping 1-bit/2-bit images.  
-Uses sample image from the [World of Horror](https://store.steampowered.com/app/913740/WORLD_OF_HORROR/) mod tools.  Please support the game.
+## kanadex-client
+Front-end react application.  Handles the display of custom WoH card images.
+### BitCanvas (custom react component)
+Draws an image and then swaps the colors in a 1-bit or 2-bit format. 
+This allows for previewing any custom game card image in your preferred color palette.
 
 ### TODO:
 * fully implement bit toggle (DONE)
 * fully implement color palette swap (DONE)
-* add better method of automagically creating palette swap buttons
+* add better method of automagically creating palette swap buttons (DONE)
+* add the remainder of in-game color palettes
 * allow for the user to preview their own image

--- a/kanadex-client/index.html
+++ b/kanadex-client/index.html
@@ -3,7 +3,8 @@
   <head>
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- <meta name="viewport" content="width=device-width, initial-scale=1.0" /> -->
+    <meta name="viewport" content="initial-scale=1, width=device-width" />
     <title>Vite + React + TS</title>
   </head>
   <body>

--- a/kanadex-client/package-lock.json
+++ b/kanadex-client/package-lock.json
@@ -14,11 +14,13 @@
         "@reduxjs/toolkit": "^1.9.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "react-redux": "^8.0.7"
+        "react-redux": "^8.0.7",
+        "react-router-dom": "^6.11.2"
       },
       "devDependencies": {
         "@types/react": "^18.0.37",
         "@types/react-dom": "^18.0.11",
+        "@types/react-router-dom": "^5.3.3",
         "@typescript-eslint/eslint-plugin": "^5.59.0",
         "@typescript-eslint/parser": "^5.59.0",
         "@vitejs/plugin-react-swc": "^3.0.0",
@@ -1025,6 +1027,14 @@
         }
       }
     },
+    "node_modules/@remix-run/router": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.6.2.tgz",
+      "integrity": "sha512-LzqpSrMK/3JBAVBI9u3NWtOhWNw5AMQfrUFYB0+bDHTSw17z++WJLsPsxAuK+oSddsxk4d7F/JcdDPM1M5YAhA==",
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/@swc/core": {
       "version": "1.3.60",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.3.60.tgz",
@@ -1219,6 +1229,12 @@
         "node": ">=10"
       }
     },
+    "node_modules/@types/history": {
+      "version": "4.7.11",
+      "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+      "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+      "dev": true
+    },
     "node_modules/@types/hoist-non-react-statics": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/@types/hoist-non-react-statics/-/hoist-non-react-statics-3.3.1.tgz",
@@ -1269,6 +1285,27 @@
       "integrity": "sha512-1vz2yObaQkLL7YFe/pme2cpvDsCwI1WXIfL+5eLz0MI9gFG24Re16RzUsI8t9XZn9ZWvgLNDrJBmrqXJO7GNQQ==",
       "dependencies": {
         "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router": {
+      "version": "5.1.20",
+      "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+      "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-router-dom": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+      "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+      "dev": true,
+      "dependencies": {
+        "@types/history": "^4.7.11",
+        "@types/react": "*",
+        "@types/react-router": "*"
       }
     },
     "node_modules/@types/react-transition-group": {
@@ -2864,6 +2901,36 @@
         "redux": {
           "optional": true
         }
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.11.2.tgz",
+      "integrity": "sha512-74z9xUSaSX07t3LM+pS6Un0T55ibUE/79CzfZpy5wsPDZaea1F8QkrsiyRnA2YQ7LwE/umaydzXZV80iDCPkMg==",
+      "dependencies": {
+        "@remix-run/router": "1.6.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.11.2",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.11.2.tgz",
+      "integrity": "sha512-JNbKtAeh1VSJQnH6RvBDNhxNwemRj7KxCzc5jb7zvDSKRnPWIFj9pO+eXqjM69gQJ0r46hSz1x4l9y0651DKWw==",
+      "dependencies": {
+        "@remix-run/router": "1.6.2",
+        "react-router": "6.11.2"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/react-transition-group": {

--- a/kanadex-client/package-lock.json
+++ b/kanadex-client/package-lock.json
@@ -8,6 +8,9 @@
       "name": "kanadex-client",
       "version": "0.0.0",
       "dependencies": {
+        "@emotion/react": "^11.11.0",
+        "@emotion/styled": "^11.11.0",
+        "@mui/material": "^5.13.3",
         "@reduxjs/toolkit": "^1.9.5",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
@@ -26,6 +29,121 @@
         "vite": "^4.3.9"
       }
     },
+    "node_modules/@babel/code-frame": {
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.21.4.tgz",
+      "integrity": "sha512-LYvhNKfwWSPpocw8GI7gpK2nq3HSDuEPC/uSYaALSJu9xjsalaaYFOq0Pwt5KmVqwEbZlDu81aLXwBOmD/Fv9g==",
+      "dependencies": {
+        "@babel/highlight": "^7.18.6"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.21.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.21.4.tgz",
+      "integrity": "sha512-orajc5T2PsRYUN3ZryCEFeMDYwyw09c/pZeaQEZPH0MpKzSvn3e0uXsDBu3k03VI+9DBiRo+l22BfKTpKwa/Wg==",
+      "dependencies": {
+        "@babel/types": "^7.21.4"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.21.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.21.5.tgz",
+      "integrity": "sha512-5pTUx3hAJaZIdW99sJ6ZUUgWq/Y+Hja7TowEnLNMm1VivRgZQL3vpBY3qUACVsvw+yQU6+YgfBVmcbLaZtrA1w==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.19.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.19.1.tgz",
+      "integrity": "sha512-awrNfaMtnHUr653GgGEs++LlAvW6w+DcPrOliSMXWCKo597CwL5Acf/wWdNkf/tfEQE3mjkeD1YOVZOUV/od1w==",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight": {
+      "version": "7.18.6",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
+      "integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.18.6",
+        "chalk": "^2.0.0",
+        "js-tokens": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw=="
+    },
+    "node_modules/@babel/highlight/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/@babel/highlight/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/@babel/runtime": {
       "version": "7.22.3",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.22.3.tgz",
@@ -36,6 +154,152 @@
       "engines": {
         "node": ">=6.9.0"
       }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.22.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.22.4.tgz",
+      "integrity": "sha512-Tx9x3UBHTTsMSW85WB2kphxYQVvrZ/t1FxD88IpSgIjiUJlCm9z+xWIDwyo1vffTwSqteqyznB8ZE9vYYk16zA==",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.21.5",
+        "@babel/helper-validator-identifier": "^7.19.1",
+        "to-fast-properties": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@emotion/babel-plugin": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.11.0.tgz",
+      "integrity": "sha512-m4HEDZleaaCH+XgDDsPF15Ht6wTLsgDTeR3WYj9Q/k76JtWhrJjcP4+/XlG8LGT/Rol9qUfOIztXeA84ATpqPQ==",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.16.7",
+        "@babel/runtime": "^7.18.3",
+        "@emotion/hash": "^0.9.1",
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/serialize": "^1.1.2",
+        "babel-plugin-macros": "^3.1.0",
+        "convert-source-map": "^1.5.0",
+        "escape-string-regexp": "^4.0.0",
+        "find-root": "^1.1.0",
+        "source-map": "^0.5.7",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/cache": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.11.0.tgz",
+      "integrity": "sha512-P34z9ssTCBi3e9EI1ZsWpNHcfY1r09ZO0rZbRO2ob3ZQMnFI35jB536qoXbkdesr5EUhYi22anuEJuyxifaqAQ==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/sheet": "^1.2.2",
+        "@emotion/utils": "^1.2.1",
+        "@emotion/weak-memoize": "^0.3.1",
+        "stylis": "4.2.0"
+      }
+    },
+    "node_modules/@emotion/hash": {
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.9.1.tgz",
+      "integrity": "sha512-gJB6HLm5rYwSLI6PQa+X1t5CFGrv1J1TWG+sOyMCeKz2ojaj6Fnl/rZEspogG+cvqbt4AE/2eIyD2QfLKTBNlQ=="
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-1.2.1.tgz",
+      "integrity": "sha512-61Mf7Ufx4aDxx1xlDeOm8aFFigGHE4z+0sKCa+IHCeZKiyP9RLD0Mmx7m8b9/Cf37f7NAvQOOJAbQQGVr5uERw==",
+      "dependencies": {
+        "@emotion/memoize": "^0.8.1"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.8.1.tgz",
+      "integrity": "sha512-W2P2c/VRW1/1tLox0mVUalvnWXxavmv/Oum2aPsRcoDJuob75FC3Y8FbpfLwUegRcxINtGUMPq0tFCvYNTBXNA=="
+    },
+    "node_modules/@emotion/react": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.11.0.tgz",
+      "integrity": "sha512-ZSK3ZJsNkwfjT3JpDAWJZlrGD81Z3ytNDsxw1LKq1o+xkmO5pnWfr6gmCC8gHEFf3nSSX/09YrG67jybNPxSUw==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.11.0",
+        "@emotion/cache": "^11.11.0",
+        "@emotion/serialize": "^1.1.2",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+        "@emotion/utils": "^1.2.1",
+        "@emotion/weak-memoize": "^0.3.1",
+        "hoist-non-react-statics": "^3.3.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/serialize": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.1.2.tgz",
+      "integrity": "sha512-zR6a/fkFP4EAcCMQtLOhIgpprZOwNmCldtpaISpvz348+DP4Mz8ZoKaGGCQpbzepNIUWbq4w6hNZkwDyKoS+HA==",
+      "dependencies": {
+        "@emotion/hash": "^0.9.1",
+        "@emotion/memoize": "^0.8.1",
+        "@emotion/unitless": "^0.8.1",
+        "@emotion/utils": "^1.2.1",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/@emotion/sheet": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.2.2.tgz",
+      "integrity": "sha512-0QBtGvaqtWi+nx6doRwDdBIzhNdZrXUppvTM4dtZZWEGTXL/XE/yJxLMGlDT1Gt+UHH5IX1n+jkXyytE/av7OA=="
+    },
+    "node_modules/@emotion/styled": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/@emotion/styled/-/styled-11.11.0.tgz",
+      "integrity": "sha512-hM5Nnvu9P3midq5aaXj4I+lnSfNi7Pmd4EWk1fOZ3pxookaQTNew6bp4JaCBYM4HVFZF9g7UjJmsUmC2JlxOng==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "@emotion/babel-plugin": "^11.11.0",
+        "@emotion/is-prop-valid": "^1.2.1",
+        "@emotion/serialize": "^1.1.2",
+        "@emotion/use-insertion-effect-with-fallbacks": "^1.0.1",
+        "@emotion/utils": "^1.2.1"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.0.0-rc.0",
+        "react": ">=16.8.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@emotion/unitless": {
+      "version": "0.8.1",
+      "resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.8.1.tgz",
+      "integrity": "sha512-KOEGMu6dmJZtpadb476IsZBclKvILjopjUii3V+7MnXIQCYh8W3NgNcgwo21n9LXZX6EDIKvqfjYxXebDwxKmQ=="
+    },
+    "node_modules/@emotion/use-insertion-effect-with-fallbacks": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@emotion/use-insertion-effect-with-fallbacks/-/use-insertion-effect-with-fallbacks-1.0.1.tgz",
+      "integrity": "sha512-jT/qyKZ9rzLErtrjGgdkMBn2OP8wl0G3sQlBb3YPryvKHsjvINUhVaPFfP+fpBcOkmrVOVEEHQFJ7nbj2TH2gw==",
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
+    "node_modules/@emotion/utils": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.2.1.tgz",
+      "integrity": "sha512-Y2tGf3I+XVnajdItskUCn6LX+VUDmP6lTL4fcqsXAv43dnlbZiuW4MWQW38rW/BVWSE7Q/7+XQocmpnRYILUmg=="
+    },
+    "node_modules/@emotion/weak-memoize": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.3.1.tgz",
+      "integrity": "sha512-EsBwpc7hBUJWAsNPBmJy4hxWx12v6bshQsldrVmjxJoc3isbxhOrF2IcCpaXxfvq03NwkI7sbsOLXbYuqF/8Ww=="
     },
     "node_modules/@esbuild/android-arm": {
       "version": "0.17.19",
@@ -478,6 +742,222 @@
       "integrity": "sha512-ZnQMnLV4e7hDlUvw8H+U8ASL02SS2Gn6+9Ac3wGGLIe7+je2AeAOxPY+izIPJDfFDb7eDjev0Us8MO1iFRN8hA==",
       "dev": true
     },
+    "node_modules/@mui/base": {
+      "version": "5.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/@mui/base/-/base-5.0.0-beta.3.tgz",
+      "integrity": "sha512-ErOMoGNpgf6BF5W+jgXDiRlXJnpSeg8XSRonuY5UCCMHIlOWtKDtt/LS3qDAbFFGb7tV/y6EBddbcMeexx+zHw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@emotion/is-prop-valid": "^1.2.1",
+        "@mui/types": "^7.2.4",
+        "@mui/utils": "^5.13.1",
+        "@popperjs/core": "^2.11.7",
+        "clsx": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/core-downloads-tracker": {
+      "version": "5.13.3",
+      "resolved": "https://registry.npmjs.org/@mui/core-downloads-tracker/-/core-downloads-tracker-5.13.3.tgz",
+      "integrity": "sha512-w4//nRIi9fiMow/MmhkForOezd8nc229EpSZZ5DzwpJNOmAXwypFTapOUVAGTUQiTJyeZXUNbQqYuUIrIs2nbg==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      }
+    },
+    "node_modules/@mui/material": {
+      "version": "5.13.3",
+      "resolved": "https://registry.npmjs.org/@mui/material/-/material-5.13.3.tgz",
+      "integrity": "sha512-10pek+Bz+PZ4rjUf3KTKfXWjPMUqU1nSnRPf4DAXABhsjzelGGfGW/EICgrLRrttYplTJZhoponWALezAge8ug==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@mui/base": "5.0.0-beta.3",
+        "@mui/core-downloads-tracker": "^5.13.3",
+        "@mui/system": "^5.13.2",
+        "@mui/types": "^7.2.4",
+        "@mui/utils": "^5.13.1",
+        "@types/react-transition-group": "^4.4.6",
+        "clsx": "^1.2.1",
+        "csstype": "^3.1.2",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0",
+        "react-transition-group": "^4.4.5"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0",
+        "react-dom": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/private-theming": {
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/@mui/private-theming/-/private-theming-5.13.1.tgz",
+      "integrity": "sha512-HW4npLUD9BAkVppOUZHeO1FOKUJWAwbpy0VQoGe3McUYTlck1HezGHQCfBQ5S/Nszi7EViqiimECVl9xi+/WjQ==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@mui/utils": "^5.13.1",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/styled-engine": {
+      "version": "5.13.2",
+      "resolved": "https://registry.npmjs.org/@mui/styled-engine/-/styled-engine-5.13.2.tgz",
+      "integrity": "sha512-VCYCU6xVtXOrIN8lcbuPmoG+u7FYuOERG++fpY74hPpEWkyFQG97F+/XfTQVYzlR2m7nPjnwVUgATcTCMEaMvw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@emotion/cache": "^11.11.0",
+        "csstype": "^3.1.2",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.4.1",
+        "@emotion/styled": "^11.3.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/system": {
+      "version": "5.13.2",
+      "resolved": "https://registry.npmjs.org/@mui/system/-/system-5.13.2.tgz",
+      "integrity": "sha512-TPyWmRJPt0JPVxacZISI4o070xEJ7ftxpVtu6LWuYVOUOINlhoGOclam4iV8PDT3EMQEHuUrwU49po34UdWLlw==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@mui/private-theming": "^5.13.1",
+        "@mui/styled-engine": "^5.13.2",
+        "@mui/types": "^7.2.4",
+        "@mui/utils": "^5.13.1",
+        "clsx": "^1.2.1",
+        "csstype": "^3.1.2",
+        "prop-types": "^15.8.1"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@emotion/react": "^11.5.0",
+        "@emotion/styled": "^11.3.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/react": {
+          "optional": true
+        },
+        "@emotion/styled": {
+          "optional": true
+        },
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/types": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@mui/types/-/types-7.2.4.tgz",
+      "integrity": "sha512-LBcwa8rN84bKF+f5sDyku42w1NTxaPgPyYKODsh01U1fVstTClbUoSA96oyRBnSNyEiAVjKm6Gwx9vjR+xyqHA==",
+      "peerDependencies": {
+        "@types/react": "*"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mui/utils": {
+      "version": "5.13.1",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.13.1.tgz",
+      "integrity": "sha512-6lXdWwmlUbEU2jUI8blw38Kt+3ly7xkmV9ljzY4Q20WhsJMWiNry9CX8M+TaP/HbtuyR8XKsdMgQW7h7MM3n3A==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0",
+        "@types/prop-types": "^15.7.5",
+        "@types/react-is": "^18.2.0",
+        "prop-types": "^15.8.1",
+        "react-is": "^18.2.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "react": "^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -511,6 +991,15 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@popperjs/core": {
+      "version": "2.11.8",
+      "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/popperjs"
       }
     },
     "node_modules/@reduxjs/toolkit": {
@@ -745,6 +1234,11 @@
       "integrity": "sha512-Hr5Jfhc9eYOQNPYO5WLDq/n4jqijdHNlDXjuAQkkt+mWdQR+XJToOHrsD4cPaMXpn6KO7y2+wM8AZEs8VpBLVA==",
       "dev": true
     },
+    "node_modules/@types/parse-json": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
+      "integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+    },
     "node_modules/@types/prop-types": {
       "version": "15.7.5",
       "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.5.tgz",
@@ -765,6 +1259,22 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.2.4.tgz",
       "integrity": "sha512-G2mHoTMTL4yoydITgOGwWdWMVd8sNgyEP85xVmMKAPUBwQWm9wBPQUmvbeF4V3WBY1P7mmL4BkjQ0SqUpf1snw==",
       "devOptional": true,
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-1vz2yObaQkLL7YFe/pme2cpvDsCwI1WXIfL+5eLz0MI9gFG24Re16RzUsI8t9XZn9ZWvgLNDrJBmrqXJO7GNQQ==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
+    "node_modules/@types/react-transition-group": {
+      "version": "4.4.6",
+      "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.6.tgz",
+      "integrity": "sha512-VnCdSxfcm08KjsJVQcfBmhEQAPnLB8G08hAxn39azX1qYBQ/5RVQuoHuKIcfKOdncuaUvEpFKFzEvbtIMsfVew==",
       "dependencies": {
         "@types/react": "*"
       }
@@ -1061,6 +1571,20 @@
         "node": ">=8"
       }
     },
+    "node_modules/babel-plugin-macros": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-3.1.0.tgz",
+      "integrity": "sha512-Cg7TFGpIr01vOQNODXOOaGz2NpCU5gl8x1qJFbb6hbZxR7XrcE2vtbAsTAbJ7/xwJtUuJEw8K8Zr/AE0LHlesg==",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5",
+        "cosmiconfig": "^7.0.0",
+        "resolve": "^1.19.0"
+      },
+      "engines": {
+        "node": ">=10",
+        "npm": ">=6"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1093,7 +1617,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -1112,6 +1635,14 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/clsx": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -1137,6 +1668,26 @@
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
+    },
+    "node_modules/convert-source-map": {
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.9.0.tgz",
+      "integrity": "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="
+    },
+    "node_modules/cosmiconfig": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-7.1.0.tgz",
+      "integrity": "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA==",
+      "dependencies": {
+        "@types/parse-json": "^4.0.0",
+        "import-fresh": "^3.2.1",
+        "parse-json": "^5.0.0",
+        "path-type": "^4.0.0",
+        "yaml": "^1.10.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -1204,6 +1755,23 @@
         "node": ">=6.0.0"
       }
     },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
+    },
+    "node_modules/error-ex": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
+      "dependencies": {
+        "is-arrayish": "^0.2.1"
+      }
+    },
     "node_modules/esbuild": {
       "version": "0.17.19",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
@@ -1245,7 +1813,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
       "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
       "engines": {
         "node": ">=10"
       },
@@ -1536,6 +2103,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/find-root": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+      "integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -1590,6 +2162,11 @@
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+      "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
     },
     "node_modules/glob": {
       "version": "7.2.3",
@@ -1670,6 +2247,17 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true
     },
+    "node_modules/has": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+      "dependencies": {
+        "function-bind": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -1714,7 +2302,6 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.0.tgz",
       "integrity": "sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==",
-      "dev": true,
       "dependencies": {
         "parent-module": "^1.0.0",
         "resolve-from": "^4.0.0"
@@ -1750,6 +2337,22 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
+    },
+    "node_modules/is-arrayish": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
+      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg=="
+    },
+    "node_modules/is-core-module": {
+      "version": "2.12.1",
+      "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.12.1.tgz",
+      "integrity": "sha512-Q4ZuBAe2FUsKtyQJoQHlvP8OvBERxO3jEmy1I7hcRXcJBGGHFh/aJBswbXuS9sgrDH2QUO8ilkwNPHvHMd8clg==",
+      "dependencies": {
+        "has": "^1.0.3"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/is-extglob": {
       "version": "2.1.1",
@@ -1813,6 +2416,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/json-parse-even-better-errors": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
+      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w=="
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -1837,6 +2445,11 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/lines-and-columns": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
+      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
     "node_modules/locate-path": {
       "version": "6.0.0",
@@ -1952,6 +2565,14 @@
       "integrity": "sha512-Tj+HTDSJJKaZnfiuw+iaF9skdPpTo2GtEly5JHnWV/hfv2Qj/9RKsGISQtLh2ox3l5EAGw487hnBee0sIJ6v2g==",
       "dev": true
     },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -2012,12 +2633,28 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
       "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "dev": true,
       "dependencies": {
         "callsites": "^3.0.0"
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/parse-json": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
+      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
+      "dependencies": {
+        "@babel/code-frame": "^7.0.0",
+        "error-ex": "^1.3.1",
+        "json-parse-even-better-errors": "^2.3.0",
+        "lines-and-columns": "^1.1.6"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/path-exists": {
@@ -2047,11 +2684,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/path-parse": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw=="
+    },
     "node_modules/path-type": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
       "integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-      "dev": true,
       "engines": {
         "node": ">=8"
       }
@@ -2110,6 +2751,21 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
     },
     "node_modules/punycode": {
       "version": "2.3.0",
@@ -2210,6 +2866,21 @@
         }
       }
     },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
+      }
+    },
     "node_modules/redux": {
       "version": "4.2.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-4.2.1.tgz",
@@ -2236,11 +2907,26 @@
       "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.8.tgz",
       "integrity": "sha512-ab9EmR80F/zQTMNeneUr4cv+jSwPJgIlvEmVwLerwrWVbpLlBuls9XHzIeTFy4cegU2NHBp3va0LKOzU5qFEYQ=="
     },
+    "node_modules/resolve": {
+      "version": "1.22.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.2.tgz",
+      "integrity": "sha512-Sb+mjNHOULsBv818T40qSPeRiuWLyaGMa5ewydRLFimneixmVy2zdivRl+AF6jaYPC8ERxGDmFSiqui6SfPd+g==",
+      "dependencies": {
+        "is-core-module": "^2.11.0",
+        "path-parse": "^1.0.7",
+        "supports-preserve-symlinks-flag": "^1.0.0"
+      },
+      "bin": {
+        "resolve": "bin/resolve"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/resolve-from": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
       "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -2362,6 +3048,14 @@
         "node": ">=8"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.5.7",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+      "integrity": "sha512-LbrmJOMUSdEVxIKvdcJzQC+nQhe8FUZQTXQy6+I75skNgn3OoQ0DZA8YnFa7gp8tqtL3KPf1kmo0R5DoApeSGQ==",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.0.2.tgz",
@@ -2395,6 +3089,11 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/stylis": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/stylis/-/stylis-4.2.0.tgz",
+      "integrity": "sha512-Orov6g6BB1sDfYgzWfTHDOxamtX1bE/zo104Dh9e6fqJ3PooipYyfJ0pUmrZO2wAvO8YbEyeFrkV91XTsGMSrw=="
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -2407,11 +3106,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/supports-preserve-symlinks-flag": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
+      "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/text-table": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
       "integrity": "sha512-N+8UisAXDGk8PFXP4HAzVR9nbfmVJ3zYLAWiTIoqC5v5isinhr+r5uaO8+7r3BMfuNIufIsA7RdpVgacC2cSpw==",
       "dev": true
+    },
+    "node_modules/to-fast-properties": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+      "integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
+      "engines": {
+        "node": ">=4"
+      }
     },
     "node_modules/to-regex-range": {
       "version": "5.0.1",
@@ -2583,6 +3301,14 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
       "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
       "dev": true
+    },
+    "node_modules/yaml": {
+      "version": "1.10.2",
+      "resolved": "https://registry.npmjs.org/yaml/-/yaml-1.10.2.tgz",
+      "integrity": "sha512-r3vXyErRCYJ7wg28yvBY5VSoAF8ZvlcW9/BwUzEtUsjvX/DKs24dIkuwjtuprwJJHsbyUbLApepYTR1BN4uHrg==",
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/yocto-queue": {
       "version": "0.1.0",

--- a/kanadex-client/package-lock.json
+++ b/kanadex-client/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
+        "@mui/icons-material": "^5.11.16",
         "@mui/material": "^5.13.3",
         "@reduxjs/toolkit": "^1.9.5",
         "react": "^18.2.0",
@@ -783,6 +784,31 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.11.16",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.11.16.tgz",
+      "integrity": "sha512-oKkx9z9Kwg40NtcIajF9uOXhxiyTZrrm9nmIJ4UjkU2IdHpd4QVLbCc/5hZN/y0C6qzi2Zlxyr9TGddQx2vx2A==",
+      "dependencies": {
+        "@babel/runtime": "^7.21.0"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0",
+        "react": "^17.0.0 || ^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/kanadex-client/package.json
+++ b/kanadex-client/package.json
@@ -16,11 +16,13 @@
     "@reduxjs/toolkit": "^1.9.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "react-redux": "^8.0.7"
+    "react-redux": "^8.0.7",
+    "react-router-dom": "^6.11.2"
   },
   "devDependencies": {
     "@types/react": "^18.0.37",
     "@types/react-dom": "^18.0.11",
+    "@types/react-router-dom": "^5.3.3",
     "@typescript-eslint/eslint-plugin": "^5.59.0",
     "@typescript-eslint/parser": "^5.59.0",
     "@vitejs/plugin-react-swc": "^3.0.0",

--- a/kanadex-client/package.json
+++ b/kanadex-client/package.json
@@ -10,6 +10,9 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@emotion/react": "^11.11.0",
+    "@emotion/styled": "^11.11.0",
+    "@mui/material": "^5.13.3",
     "@reduxjs/toolkit": "^1.9.5",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/kanadex-client/package.json
+++ b/kanadex-client/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0",
+    "@mui/icons-material": "^5.11.16",
     "@mui/material": "^5.13.3",
     "@reduxjs/toolkit": "^1.9.5",
     "react": "^18.2.0",

--- a/kanadex-client/src/App.tsx
+++ b/kanadex-client/src/App.tsx
@@ -1,72 +1,16 @@
 // App.tsx
-import BitCanvas from './BitCanvas'
-import { useAppDispatch, useAppSelector } from './app/Hooks'
-import { setColorPallete, toggleTwoBitsFlag } from './features/ColorPalettes/ColorPaletteSlice'
-import { ALL_PALETTES, ColorPalette } from './features/ColorPalettes/ColorPalettes'
 
 import './App.css'
 import testImage from './assets/violin_concerto.png'
-import { Button, Card, CardActions, CardContent, CssBaseline, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent, Switch, ThemeProvider, Typography, createTheme } from '@mui/material'
 
 function App() {
-  const colorPalette = useAppSelector((state) => state.colorPalette);
-  const dispatch = useAppDispatch();
+
 
   const image = new Image(195, 164);
   image.src = testImage;
 
-  const handleBitToggleClick = () => 
-  {
-    dispatch(toggleTwoBitsFlag());
-  }
-
-  const handlePalleteSwap = (palette: string) =>
-  {
-    ALL_PALETTES.forEach(p => {
-      if (p.name == palette)
-      {
-        dispatch(setColorPallete(p));
-      }
-    });
-  }
-
-  const darkTheme = createTheme({
-    palette: {
-      mode: "dark",
-    }
-  })
-
   return (
     <>
-      <ThemeProvider theme={ darkTheme }>
-        <CssBaseline />
-        <Card>
-          <CardContent>
-            <BitCanvas baseImage={image} width={image.width} height={image.height} />
-            <Typography variant="h5" component="div">
-              violin concerto
-            </Typography>
-          </CardContent>
-          <CardActions>
-            <Button size="small">Would you like to know more?</Button>
-          </CardActions>
-        </Card>
-        <Switch defaultChecked onChange={handleBitToggleClick} />
-        <FormControl>
-          <InputLabel id="palette-select-label">Palette</InputLabel>
-          <Select
-            labelId="palette-select-label"
-            id="palette-select"
-            value={colorPalette.palette.name}
-            label="Palette"
-            onChange={(event) => handlePalleteSwap(event.target.value)}
-          >
-            {ALL_PALETTES.map((value: ColorPalette, index) => 
-              (<MenuItem key={index} value={value.name}>{value.name}</MenuItem>)
-            )}
-          </Select>
-        </FormControl>
-      </ThemeProvider>
     </>
   )
 }

--- a/kanadex-client/src/App.tsx
+++ b/kanadex-client/src/App.tsx
@@ -2,10 +2,11 @@
 import BitCanvas from './BitCanvas'
 import { useAppDispatch, useAppSelector } from './app/Hooks'
 import { setColorPallete, toggleTwoBitsFlag } from './features/ColorPalettes/ColorPaletteSlice'
-import { DEFAULT_PALETTE, GOTHIC, RETRO_DARK } from './features/ColorPalettes/ColorPalettes'
+import { ALL_PALETTES, ColorPalette } from './features/ColorPalettes/ColorPalettes'
 
 import './App.css'
 import testImage from './assets/violin_concerto.png'
+import { Button, Card, CardActions, CardContent, CssBaseline, FormControl, InputLabel, MenuItem, Select, SelectChangeEvent, Switch, ThemeProvider, Typography, createTheme } from '@mui/material'
 
 function App() {
   const colorPalette = useAppSelector((state) => state.colorPalette);
@@ -21,48 +22,51 @@ function App() {
 
   const handlePalleteSwap = (palette: string) =>
   {
-    switch (palette)
-    {
-      case("retro (dark)"):
-        dispatch(setColorPallete(RETRO_DARK));
-        break;
-      case("gothic"):
-        dispatch(setColorPallete(GOTHIC));   
-        break;
-      case("default"):  
-      default:
-        dispatch(setColorPallete(DEFAULT_PALETTE));
-        break;
-    }
+    ALL_PALETTES.forEach(p => {
+      if (p.name == palette)
+      {
+        dispatch(setColorPallete(p));
+      }
+    });
   }
 
+  const darkTheme = createTheme({
+    palette: {
+      mode: "dark",
+    }
+  })
 
   return (
     <>
-      <h1>WoH BitCanvas</h1>
-      <div className="card">
-          <button onClick={handleBitToggleClick}>{colorPalette.twoBitsFlag? 2 : 1} bits</button>
-      </div>
-      <div className="card">
-          <button onClick={() => handlePalleteSwap('default')}>default</button>
-          <button onClick={() => handlePalleteSwap('retro (dark)')}>gameboy</button>
-          <button onClick={() => handlePalleteSwap('gothic')}>gothic</button>
-      </div>
-      <div className="card">
-          <BitCanvas baseImage={image} width={195} height={164} />
-      </div>
-      <div className="card">
-        <p>todo</p>
-        <ul>
-          <li>(DONE) bit toggle</li>
-          <li>(DONE) color palette swap</li>
-          <li>add more palettes programmatically</li>
-          <li>allow using a custom image</li>
-        </ul>
-      </div>
-      <p className="read-the-docs">
-        [this space intentionally left blank]
-      </p>
+      <ThemeProvider theme={ darkTheme }>
+        <CssBaseline />
+        <Card>
+          <CardContent>
+            <BitCanvas baseImage={image} width={image.width} height={image.height} />
+            <Typography variant="h5" component="div">
+              violin concerto
+            </Typography>
+          </CardContent>
+          <CardActions>
+            <Button size="small">Would you like to know more?</Button>
+          </CardActions>
+        </Card>
+        <Switch defaultChecked onChange={handleBitToggleClick} />
+        <FormControl>
+          <InputLabel id="palette-select-label">Palette</InputLabel>
+          <Select
+            labelId="palette-select-label"
+            id="palette-select"
+            value={colorPalette.palette.name}
+            label="Palette"
+            onChange={(event) => handlePalleteSwap(event.target.value)}
+          >
+            {ALL_PALETTES.map((value: ColorPalette, index) => 
+              (<MenuItem key={index} value={value.name}>{value.name}</MenuItem>)
+            )}
+          </Select>
+        </FormControl>
+      </ThemeProvider>
     </>
   )
 }

--- a/kanadex-client/src/BitCanvas.tsx
+++ b/kanadex-client/src/BitCanvas.tsx
@@ -88,7 +88,7 @@ function BitCanvas({baseImage, width, height}: BitCanvasProps) {
             {
                 // grab the hex value, (optionally) translate it to the selected palette, then set the rgb values manually
                 const originalHex = getColorString(imgData.data[i], imgData.data[i + 1], imgData.data[i + 2])
-                const translatedHex = translateColor(originalHex, colorPalette.twoBitsFlag, ...colorPalette.colors); 
+                const translatedHex = translateColor(originalHex, colorPalette.twoBitsFlag, ...colorPalette.palette.colors); 
                 const [r, g, b] = getColorValues(translatedHex);
 
                 imgData.data[i] = r;
@@ -109,7 +109,7 @@ function BitCanvas({baseImage, width, height}: BitCanvasProps) {
             ref={canvasRef}
             width={width}
             height={height}
-            style={{ border: "2px solid black"}}
+            style={{ border: "2px solid black", width: "100%", height: "100%",}}
         />
     )
 }

--- a/kanadex-client/src/BitCanvas.tsx
+++ b/kanadex-client/src/BitCanvas.tsx
@@ -1,6 +1,6 @@
 // BitCanvas.tsx
 
-import { useRef } from "react";
+import { useEffect, useRef } from "react";
 import { useAppSelector } from "./app/Hooks";
 
 export interface BitCanvasProps {
@@ -55,7 +55,7 @@ const translateColor = (hex: string, twoBit: boolean, ...altColors: string[]): s
 function BitCanvas({baseImage, width, height}: BitCanvasProps) {
 
     const canvasRef = useRef<HTMLCanvasElement | null>(null);
-    const context = canvasRef.current?.getContext('2d');
+    let context: CanvasRenderingContext2D;
 
     const colorPalette = useAppSelector((state) => state.colorPalette);
 
@@ -65,7 +65,10 @@ function BitCanvas({baseImage, width, height}: BitCanvasProps) {
     // handle loading the original image
     const loadImage = () =>
     {
-        if (!context) return;
+        if (!canvasRef.current) return;
+        let ctx = canvasRef.current.getContext('2d', { willReadFrequently: true });
+        if (!ctx) return;
+        context = ctx;
         context.drawImage(baseImage, 0, 0);
         ORIGINAL_IMAGE_DATA = context.getImageData(0, 0, width, height);
     }
@@ -100,9 +103,12 @@ function BitCanvas({baseImage, width, height}: BitCanvasProps) {
         }
     }
 
-
-    loadImage()
-    drawImage()
+    useEffect(() => {
+        const initialLoad = async () => {
+            loadImage();
+        }
+        initialLoad().finally(() => drawImage())
+    });
 
     return (
         <canvas 

--- a/kanadex-client/src/ErrorPage.tsx
+++ b/kanadex-client/src/ErrorPage.tsx
@@ -1,0 +1,21 @@
+import { useRouteError, isRouteErrorResponse } from "react-router-dom";
+
+export default function ErrorPage()
+{
+    const error = useRouteError();
+    console.error(error);
+
+    return (
+        <div id="error-page">
+            <h1>Oopsie woopsie</h1>
+            <p>An unexpected problem has occured.</p>
+            {
+                isRouteErrorResponse(error) ?
+                (<p>{error.statusText || error.error?.message}</p>)
+                :
+                "Unknown error, our bad"
+            }
+            
+        </div>
+    )
+}

--- a/kanadex-client/src/features/ColorPalettes/ColorPaletteSlice.ts
+++ b/kanadex-client/src/features/ColorPalettes/ColorPaletteSlice.ts
@@ -2,15 +2,15 @@
 
 import { createSlice, PayloadAction } from '@reduxjs/toolkit'
 
-import { DEFAULT_PALETTE } from './ColorPalettes';
+import { ColorPalette, DEFAULT_PALETTE } from './ColorPalettes';
 
 interface ColorPalleteState {
-    colors: string[];
+    palette: ColorPalette;
     twoBitsFlag: boolean;
 }
 
 const initialState: ColorPalleteState = {
-    colors: DEFAULT_PALETTE,
+    palette: DEFAULT_PALETTE,
     twoBitsFlag: true,
 };
 
@@ -21,8 +21,8 @@ const colorPaletteSlice = createSlice({
         toggleTwoBitsFlag(state) {
             state.twoBitsFlag = !state.twoBitsFlag;
         },
-        setColorPallete(state, action: PayloadAction<string[]>) {
-            state.colors = [...action.payload]
+        setColorPallete(state, action: PayloadAction<ColorPalette>) {
+            state.palette = action.payload;
         },
     }
 });

--- a/kanadex-client/src/features/ColorPalettes/ColorPalettes.ts
+++ b/kanadex-client/src/features/ColorPalettes/ColorPalettes.ts
@@ -6,6 +6,22 @@
 // "FF40FF"; // bright pink
 // "C000C0"; // dark pink
 
-export const DEFAULT_PALETTE = ["000000", "ffffff", "ff40ff", "c000c0"];
-export const RETRO_DARK = ["182005","769518","3c4d0c","182005"];
-export const GOTHIC = ["3f352d", "b3ab98", "a83d33", "7b8779"];
+export interface ColorPalette {
+    name: string,
+    colors: string[],
+}
+
+// factory to create objects
+// I am NOT creating them all manually
+const createPalette = (name: string, colors: string[]): ColorPalette => {
+    return {
+        name: name,
+        colors: colors
+    }
+}
+
+
+export const DEFAULT_PALETTE = createPalette("Stock", ["000000", "ffffff", "ff40ff", "c000c0"]);
+export const RETRO_DARK = createPalette("Retro (Dark)", ["182005","769518","3c4d0c","182005"]);
+export const GOTHIC = createPalette("Gothic", ["3f352d", "b3ab98", "a83d33", "7b8779"]);
+export const ALL_PALETTES = [DEFAULT_PALETTE, RETRO_DARK, GOTHIC];

--- a/kanadex-client/src/main.tsx
+++ b/kanadex-client/src/main.tsx
@@ -1,14 +1,45 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { Provider } from 'react-redux';
+import { RouterProvider, createBrowserRouter } from 'react-router-dom';
+import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
+
 import { store } from './app/Store.ts';
 import App from './App.tsx'
 import './index.css'
+import Root from './scenes/root/index.tsx';
+import Gallery from './scenes/gallery/index.tsx';
+import ErrorPage from './ErrorPage.tsx';
+
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <Root />,
+    errorElement: <ErrorPage />,
+    children: [
+      {
+        path: "gallery",
+        element: <Gallery />,
+      }
+    ]
+  }
+])
+
+const darkTheme = createTheme({
+  palette: {
+    mode: "dark",
+  }
+})
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
     <Provider store={store}>
-      <App />
+      <ThemeProvider theme={ darkTheme }>
+        <CssBaseline />
+        <RouterProvider router={router} />
+      </ThemeProvider>
+      {/*<App />*/}
     </Provider>
   </React.StrictMode>
 )

--- a/kanadex-client/src/main.tsx
+++ b/kanadex-client/src/main.tsx
@@ -5,11 +5,14 @@ import { RouterProvider, createBrowserRouter } from 'react-router-dom';
 import { CssBaseline, ThemeProvider, createTheme } from '@mui/material';
 
 import { store } from './app/Store.ts';
-import App from './App.tsx'
 import './index.css'
+import './App.css'
+
+import Index from './scenes/index.tsx';
 import Root from './scenes/root/index.tsx';
 import Gallery from './scenes/gallery/index.tsx';
 import ErrorPage from './ErrorPage.tsx';
+
 
 
 const router = createBrowserRouter([
@@ -18,6 +21,10 @@ const router = createBrowserRouter([
     element: <Root />,
     errorElement: <ErrorPage />,
     children: [
+      {
+        index: true,
+        element: <Index />
+      },
       {
         path: "gallery",
         element: <Gallery />,

--- a/kanadex-client/src/scenes/gallery/index.tsx
+++ b/kanadex-client/src/scenes/gallery/index.tsx
@@ -1,0 +1,32 @@
+// src/scenes/gallery/index.tsx
+
+import { Button, Card, CardActions, CardContent, Typography } from '@mui/material';
+
+import testImage from '../../assets/violin_concerto.png'
+import BitCanvas from '../../BitCanvas';
+
+function Gallery()
+{
+
+    const image = new Image(195, 164);
+    image.src = testImage;
+
+
+    return (
+        <>
+            <Card>
+                <CardContent>
+                    <BitCanvas baseImage={image} width={image.width} height={image.height} />
+                    <Typography variant="h5" component="div">
+                        violin concerto
+                    </Typography>
+                </CardContent>
+                <CardActions>
+                    <Button size="small">Would you like to know more?</Button>
+                </CardActions>
+            </Card>
+        </>
+    )
+}
+
+export default Gallery;

--- a/kanadex-client/src/scenes/gallery/index.tsx
+++ b/kanadex-client/src/scenes/gallery/index.tsx
@@ -1,6 +1,6 @@
 // src/scenes/gallery/index.tsx
 
-import { Button, Card, CardActions, CardContent, Typography } from '@mui/material';
+import { Box, Button, Card, CardActions, CardContent, Typography } from '@mui/material';
 
 import testImage from '../../assets/violin_concerto.png'
 import BitCanvas from '../../BitCanvas';
@@ -13,19 +13,21 @@ function Gallery()
 
 
     return (
-        <>
-            <Card>
-                <CardContent>
-                    <BitCanvas baseImage={image} width={image.width} height={image.height} />
-                    <Typography variant="h5" component="div">
-                        violin concerto
-                    </Typography>
-                </CardContent>
-                <CardActions>
-                    <Button size="small">Would you like to know more?</Button>
-                </CardActions>
-            </Card>
-        </>
+        <Box sx={{ display: 'flex', flexWrap: 'wrap' }}>
+            {['a', 'b', 'c', 'd', 'e'].map((value) => (
+                <Card sx={{ margin: "1em" }}>
+                    <CardContent>
+                        <BitCanvas baseImage={image} width={image.width} height={image.height} />
+                        <Typography variant="h5" component="div">
+                            violin concerto {value}
+                        </Typography>
+                    </CardContent>
+                    <CardActions>
+                        <Button size="small">Would you like to know more?</Button>
+                    </CardActions>
+                </Card>
+            ))}
+        </Box>
     )
 }
 

--- a/kanadex-client/src/scenes/index.tsx
+++ b/kanadex-client/src/scenes/index.tsx
@@ -1,0 +1,13 @@
+import { Card, Typography } from "@mui/material";
+
+function Index()
+{
+    return (
+        <Card sx={{ padding: "1em" }}>
+            <Typography variant="h1">KanaDex</Typography>
+            <Typography variant="subtitle1">[this space intentionally left blank]</Typography>
+        </Card>
+    )
+}
+
+export default Index;

--- a/kanadex-client/src/scenes/root/index.tsx
+++ b/kanadex-client/src/scenes/root/index.tsx
@@ -1,4 +1,6 @@
-import { Box, Divider, Drawer, FormControl, InputLabel, List, ListItem, ListItemButton, MenuItem, Select, Switch } from "@mui/material";
+import { Box, Divider, Drawer, FormControl, InputLabel, List, ListItem, ListItemButton, ListItemIcon, ListItemText, MenuItem, Select, Switch, Typography } from "@mui/material";
+import HomeIcon from "@mui/icons-material/Home"
+import CollectionsIcon from '@mui/icons-material/Collections';
 
 import { ALL_PALETTES, ColorPalette } from "../../features/ColorPalettes/ColorPalettes";
 import { useAppDispatch, useAppSelector } from "../../app/Hooks";
@@ -35,14 +37,30 @@ function Root()
             <Drawer
                 variant="permanent"
                 anchor="left"
-                sx={{ width: drawerWidth, flexShrink: 0, '& .MuiDrawer-paper': {width: drawerWidth, boxSizing: "border-box"} }}
+                sx={{ width: drawerWidth, flexShrink: 0, 
+                    '& .MuiDrawer-paper': {width: drawerWidth, boxSizing: "border-box"},
+                 }}
                 >
                 <List>
+                    <ListItem>                  
+                        <ListItemText><Typography variant="h5">KanaDex</Typography></ListItemText>
+                    </ListItem>
+                    <Divider />
                     <ListItem>
-                        <Link to={'/'}><ListItemButton>Home</ListItemButton></Link>
+                        <Link to={'/'}>
+                            <ListItemButton>
+                                <ListItemIcon><HomeIcon /></ListItemIcon>
+                                <Typography variant="h5">Home</Typography>
+                            </ListItemButton>
+                        </Link>
                     </ListItem>
                     <ListItem>
-                        <Link to={'gallery'}><ListItemButton>Gallery</ListItemButton></Link>
+                        <Link to={'gallery'}>
+                                <ListItemButton>
+                                    <ListItemIcon><CollectionsIcon /></ListItemIcon>
+                                    <Typography variant="h5">Gallery</Typography>
+                                </ListItemButton>
+                            </Link>
                     </ListItem>
                     <Divider />
                     <ListItem>

--- a/kanadex-client/src/scenes/root/index.tsx
+++ b/kanadex-client/src/scenes/root/index.tsx
@@ -1,0 +1,76 @@
+import { Box, Divider, Drawer, FormControl, InputLabel, List, ListItem, ListItemButton, MenuItem, Select, Switch } from "@mui/material";
+
+import { ALL_PALETTES, ColorPalette } from "../../features/ColorPalettes/ColorPalettes";
+import { useAppDispatch, useAppSelector } from "../../app/Hooks";
+import { setColorPallete, toggleTwoBitsFlag } from "../../features/ColorPalettes/ColorPaletteSlice";
+import { Link, Outlet } from "react-router-dom";
+
+
+
+
+function Root()
+{
+    const drawerWidth = 200;
+
+    const colorPalette = useAppSelector((state) => state.colorPalette);
+    const dispatch = useAppDispatch();
+
+    const handleBitToggleClick = () => 
+    {
+      dispatch(toggleTwoBitsFlag());
+    }
+  
+    const handlePalleteSwap = (palette: string) =>
+    {
+      ALL_PALETTES.forEach(p => {
+        if (p.name == palette)
+        {
+          dispatch(setColorPallete(p));
+        }
+      });
+    }
+
+    return (
+        <Box sx={{ display: "flex" }}>
+            <Drawer
+                variant="permanent"
+                anchor="left"
+                sx={{ width: drawerWidth, flexShrink: 0, '& .MuiDrawer-paper': {width: drawerWidth, boxSizing: "border-box"} }}
+                >
+                <List>
+                    <ListItem>
+                        <Link to={'/'}><ListItemButton>Home</ListItemButton></Link>
+                    </ListItem>
+                    <ListItem>
+                        <Link to={'gallery'}><ListItemButton>Gallery</ListItemButton></Link>
+                    </ListItem>
+                    <Divider />
+                    <ListItem>
+                        2-Bit <Switch defaultChecked onChange={handleBitToggleClick} />
+                    </ListItem>
+                    <ListItem>
+                        <FormControl>
+                            <InputLabel id="palette-select-label">Palette</InputLabel>
+                            <Select
+                                labelId="palette-select-label"
+                                id="palette-select"
+                                value={colorPalette.palette.name}
+                                label="Palette"
+                                onChange={(event) => handlePalleteSwap(event.target.value)}
+                            >
+                                {ALL_PALETTES.map((value: ColorPalette, index) => 
+                                    (<MenuItem key={index} value={value.name}>{value.name}</MenuItem>)
+                                )}
+                            </Select>
+                        </FormControl>
+                    </ListItem>
+                </List>
+            </Drawer>
+            <Box sx={{ flexGrow: 1 }}>
+                <Outlet />
+            </Box>
+        </Box>
+    )
+}
+
+export default Root;


### PR DESCRIPTION
Added a permanent toolbar anchored to the left side of the screen.  
This toolbar has links to the landing page and the 'Gallery', and also palette-swap controls.

Added the 'Gallery' page, which is the same as the previous landing page but with multiple clones of the same picture.  This will be populated with different pictures at some point, but for now will serve for demonstrating that the palette swap controls do in fact work.

Partial fix for a bug where the BitCanvas would not render upon init.  Still occurs if you directly navigate to the Gallery via typing and entering the direct URL.

![2023-06-02 22-22-52](https://github.com/konnorcollins/kanadex/assets/34384755/3f6cce09-8e2c-4391-b960-1e3e16dac840)
